### PR TITLE
10 unable to update user information for the user in case of duplicate nickname

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: kaw393939/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
+          tags: Bhupendra437/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
           platforms: linux/amd64,linux/arm64 # Multi-platform support
           cache-from: type=registry,ref=kaw393939/wis_club_api:cache
           cache-to: type=inline,mode=max
@@ -78,7 +78,7 @@ jobs:
       - name: Scan the Docker image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'kaw393939/wis_club_api:${{ github.sha }}'
+          image-ref: 'Bhupendra437/wis_club_api:${{ github.sha }}'
           format: 'table'
           exit-code: '1' # Fail the job if vulnerabilities are found
           ignore-unfixed: true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: bhupendrakha/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
+          tags: bhupendrakha/final_project:${{ github.sha }} # Uses the Git SHA for tagging
           platforms: linux/amd64,linux/arm64 # Multi-platform support
           cache-from: type=registry,ref=kaw393939/wis_club_api:cache
           cache-to: type=inline,mode=max
@@ -78,7 +78,7 @@ jobs:
       - name: Scan the Docker image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'bhupendrakha/wis_club_api:${{ github.sha }}'
+          image-ref: 'bhupendrakha/final_project:${{ github.sha }}'
           format: 'table'
           exit-code: '1' # Fail the job if vulnerabilities are found
           ignore-unfixed: true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,7 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: Bhupendra437/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
+          tags: bhupendrakha/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
           platforms: linux/amd64,linux/arm64 # Multi-platform support
           cache-from: type=registry,ref=kaw393939/wis_club_api:cache
           cache-to: type=inline,mode=max
@@ -78,7 +78,7 @@ jobs:
       - name: Scan the Docker image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'Bhupendra437/wis_club_api:${{ github.sha }}'
+          image-ref: 'bhupendrakha/wis_club_api:${{ github.sha }}'
           format: 'table'
           exit-code: '1' # Fail the job if vulnerabilities are found
           ignore-unfixed: true

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -27,7 +27,7 @@ async def get_db() -> AsyncSession:
             raise HTTPException(status_code=500, detail=str(e))
         
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
 
 def get_current_user(token: str = Depends(oauth2_scheme)):
     credentials_exception = HTTPException(

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -106,6 +106,15 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
     - **user_update**: UserUpdate model with updated user information.
     """
     user_data = user_update.model_dump(exclude_unset=True)
+
+    existing_user = await UserService.get_by_email(db, user_update.email)
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already exists")
+    
+    existing_user_nickname = await UserService.get_by_nickname(db, user_update.nickname)
+    if existing_user_nickname:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nickname already exists")
+    
     updated_user = await UserService.update(db, user_id, user_data)
     if not updated_user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -71,10 +71,10 @@ class UserService:
 
             else:
                 new_user.verification_token = generate_verification_token()
-                await email_service.send_verification_email(new_user)
 
             session.add(new_user)
             await session.commit()
+            await email_service.send_verification_email(new_user)
             return new_user
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -83,7 +83,14 @@ class UserService:
         try:
             # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdate(**update_data).model_dump(exclude_unset=True)
-
+            existing_user = await cls.get_by_email(session, validated_data['email'])
+            if existing_user:
+                logger.error("User with given email already exists.")
+                return None
+            existing_user_nickname = await cls.get_by_nickname(session, validated_data['nickname'])
+            if existing_user_nickname:
+                logger.error("User with given nickname already exists.")
+                return None           
             if 'password' in validated_data:
                 validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             query = update(User).where(User.id == user_id).values(**validated_data).execution_options(synchronize_session="fetch")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -69,9 +69,7 @@ class UserService:
             if new_user.role == UserRole.ADMIN:
                 new_user.email_verified = True
 
-            else:
-                new_user.verification_token = generate_verification_token()
-
+            new_user.verification_token = generate_verification_token()
             session.add(new_user)
             await session.commit()
             await email_service.send_verification_email(new_user)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -168,7 +168,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED
             session.add(user)
             await session.commit()
             return True

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -1,6 +1,9 @@
 import logging.config
 import os
 from app.dependencies import get_settings
+from jose import jwt
+from datetime import datetime, timedelta
+from settings.config import settings
 
 settings = get_settings()
 def setup_logging():

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -6,6 +6,12 @@ from app.models.user_model import User, UserRole
 from app.utils.nickname_gen import generate_nickname
 from app.utils.security import hash_password
 from app.services.jwt_service import decode_token  # Import your FastAPI app
+from datetime import datetime
+import sqlalchemy as sa
+import bcrypt
+import uuid
+from sqlalchemy import insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 # Example of a test function using the async_client fixture
 @pytest.mark.asyncio
@@ -45,7 +51,7 @@ async def test_update_user_email_access_denied(async_client, verified_user, user
 
 @pytest.mark.asyncio
 async def test_update_user_email_access_allowed(async_client, admin_user, admin_token):
-    updated_data = {"email": f"updated_{admin_user.id}@example.com"}
+    updated_data = {"email": f"updated_{admin_user.id}@example.com", "nickname": "new_nickname"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200
@@ -150,17 +156,56 @@ async def test_delete_user_does_not_exist(async_client, admin_token):
     delete_response = await async_client.delete(f"/users/{non_existent_user_id}", headers=headers)
     assert delete_response.status_code == 404
 
-@pytest.mark.asyncio
-async def test_update_user_github(async_client, admin_user, admin_token):
-    updated_data = {"github_profile_url": "http://www.github.com/kaw393939"}
-    headers = {"Authorization": f"Bearer {admin_token}"}
-    response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
-    assert response.status_code == 200
-    assert response.json()["github_profile_url"] == updated_data["github_profile_url"]
+@pytest.fixture
+async def test_user(db_session):
+    new_user = User(
+        id=uuid.uuid4(),  # Ensure a unique ID if not automatically generated
+        email="testuser@example.com",
+        nickname="TestUser",
+        role="ADMIN"  # Assuming 'USER' is a valid role in your schema
+    )
+    password = "securepassword"
+    hashed_password = bcrypt.hashpw(password.encode(), bcrypt.gensalt())
+    new_user.hashed_password = hashed_password.decode()  # Ensure the hashed password is correctly assigned
+    
+    # Add the new user to the session and commit
+    db_session.add(new_user)
+    await db_session.commit()
+    return new_user
 
 @pytest.mark.asyncio
-async def test_update_user_linkedin(async_client, admin_user, admin_token):
-    updated_data = {"linkedin_profile_url": "http://www.linkedin.com/kaw393939"}
+async def test_update_user_github(async_client, test_user, admin_token, db_session):
+    unique_email = f"{datetime.now().timestamp()}_{test_user.email}"
+    updated_data = {"email": unique_email, "github_profile_url": "http://www.github.com/kaw393939", "nickname": "UpdatedNickname"}
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Fetch and print user details before update
+    pre_update = await async_client.get(f"/users/{test_user.id}", headers=headers)
+    print("Pre-Update User Data:", pre_update.json())
+
+    # Direct database check
+    result = await db_session.execute(sa.select(User).where(User.id == test_user.id))
+    db_user = result.scalars().first()
+    if db_user:
+        print("Database User Check: User found")
+    else:
+        print("Database User Check: User NOT found")
+
+    # Attempt to update the user
+    response = await async_client.put(f"/users/{test_user.id}", json=updated_data, headers=headers)
+    print("Update Response:", response.json())  # Print response to see detailed error or message
+
+    # Assert the update was successful
+    assert response.status_code == 200, f"Expected 200 OK, got {response.status_code} with message {response.text}"
+
+    # Fetch and print user details after update attempt
+    post_update = await async_client.get(f"/users/{test_user.id}", headers=headers)
+    print("Post-Update User Data:", post_update.json())
+
+@pytest.mark.asyncio
+async def test_update_user_linkedin(async_client, admin_user, admin_token, db_session):
+    unique_email = f"{datetime.now().timestamp()}_{admin_user.email}"
+    updated_data = {"email": unique_email, "linkedin_profile_url": "http://www.linkedin.com/kaw393939", "nickname": "UpdatedNickname"}
     headers = {"Authorization": f"Bearer {admin_token}"}
     response = await async_client.put(f"/users/{admin_user.id}", json=updated_data, headers=headers)
     assert response.status_code == 200

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -64,7 +64,7 @@ async def test_get_by_email_user_does_not_exist(db_session):
 # Test updating a user with valid data
 async def test_update_user_valid_data(db_session, user):
     new_email = "updated_email@example.com"
-    updated_user = await UserService.update(db_session, user.id, {"email": new_email})
+    updated_user = await UserService.update(db_session, user.id, {"email": new_email, "nickname": "new_nickname"})
     assert updated_user is not None
     assert updated_user.email == new_email
 


### PR DESCRIPTION
The update was generating a silent response as pass even though the fastapi log was erroring for duplicate email or nickname. With this bug fix, the request will generate 404 error in case of duplicate email or nickname during update operation.