### PR TITLE
Bug#1 : Handle the case when limit for fetching the list of users is 0.

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,15 +70,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: kaw393939/wis_club_api:${{ github.sha }} # Uses the Git SHA for tagging
+          tags: redmangoapple/usermng:${{ github.sha }} # Uses the Git SHA for tagging
           platforms: linux/amd64,linux/arm64 # Multi-platform support
-          cache-from: type=registry,ref=kaw393939/wis_club_api:cache
+          cache-from: type=registry,ref=redmangoapple/usermng:cache
           cache-to: type=inline,mode=max
           
       - name: Scan the Docker image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'kaw393939/wis_club_api:${{ github.sha }}'
+          image-ref: 'redmangoapple/usermng:${{ github.sha }}'
           format: 'table'
           exit-code: '1' # Fail the job if vulnerabilities are found
           ignore-unfixed: true

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -173,23 +173,26 @@ async def list_users(
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):
-    total_users = await UserService.count(db)
-    users = await UserService.list_users(db, skip, limit)
+    if limit>0:
+        total_users = await UserService.count(db)
+        users = await UserService.list_users(db, skip, limit)
 
-    user_responses = [
-        UserResponse.model_validate(user) for user in users
-    ]
+        user_responses = [
+            UserResponse.model_validate(user) for user in users
+        ]
+
+        pagination_links = generate_pagination_links(request, skip, limit, total_users)
+
+        # Construct the final response with pagination details
+        return UserListResponse(
+            items=user_responses,
+            total=total_users,
+            page=skip // limit + 1,
+            size=len(user_responses),
+            links=pagination_links  # Ensure you have appropriate logic to create these links
+        )
+    raise HTTPException(status_code=400, detail="Limit must be greater than 0")
     
-    pagination_links = generate_pagination_links(request, skip, limit, total_users)
-    
-    # Construct the final response with pagination details
-    return UserListResponse(
-        items=user_responses,
-        total=total_users,
-        page=skip // limit + 1,
-        size=len(user_responses),
-        links=pagination_links  # Ensure you have appropriate logic to create these links
-    )
 
 
 @router.post("/register/", response_model=UserResponse, tags=["Login and Registration"])

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -184,6 +184,16 @@ async def test_list_users_as_manager(async_client, manager_token):
     assert response.status_code == 200
 
 @pytest.mark.asyncio
+async def test_list_users_0_pagination(async_client, admin_token):
+    response = await async_client.get(
+        "/users/?limit=0&skip=0",
+        headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert response.status_code == 400
+    assert "Limit must be greater than 0" in response.json().get("detail", "")
+
+
+@pytest.mark.asyncio
 async def test_list_users_unauthorized(async_client, user_token):
     response = await async_client.get(
         "/users/",


### PR DESCRIPTION
To address the Internal Server Error when attempting to fetch a list of users with a pagination limit set to 0, we propose the following solution:

1.Parameter Validation: Before executing the request, validate the pagination limit parameter. If the limit is greater than 0, proceed with the request as usual. However, if the limit is 0 or less, indicating an invalid pagination setting, return a 400 Bad Request error along with a message stating "Limit must be greater than 0". This error message clearly indicates that the limit parameter must be a positive integer.

2.Clarification on Pagination Limit: It's crucial to provide clarification regarding the pagination limit. Pagination limits typically define the maximum number of items displayed on each page of results. Therefore, setting the limit to 0 effectively disables pagination, resulting in an attempt to fetch an empty list of users. This clarification ensures that users understand the purpose and implications of the pagination limit parameter.

By implementing these changes, the API will handle pagination limits more robustly, ensuring that only valid values are accepted and preventing unexpected server errors caused by invalid input parameters.






