### PR TITLE
Fix/nickname preserve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /myapp
 
 # Update system and specifically upgrade libc-bin to the required security patch version
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u7 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#     gcc \
+#     libpq-dev \
+#     && apt-get install -y libc-bin=2.36-9+deb12u7 \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies in /.venv
 COPY requirements.txt .
@@ -30,9 +30,9 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
+#     && apt-get clean \
+#     && rm -rf /var/lib/apt/lists/*
 
 # Copy the virtual environment from the base stage
 COPY --from=base /.venv /.venv

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -36,14 +36,6 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., min_length=8, example="Secure*1234")
-    nickname: str
-    first_name: Optional[str]
-    last_name: Optional[str]
-    bio: Optional[str]
-    profile_picture_url: Optional[HttpUrl]
-    linkedin_profile_url: Optional[HttpUrl]
-    github_profile_url: Optional[HttpUrl]
-    role: Optional[str]
 
     @validator('password')
     def password_must_not_be_blank(cls, value):
@@ -52,19 +44,11 @@ class UserCreate(UserBase):
         if len(value) < 8:
             raise ValueError("Password must be at least 8 characters long.")
         return value
-    
-    @validator("github_profile_url")
-    def validate_github_url(cls, v: HttpUrl):
-        v_str = str(v)
-        if not v_str.startswith("https://github.com/"):
-            raise ValueError("GitHub profile URL must start with https://github.com/")
-        return v
 
-    @validator("linkedin_profile_url")
-    def validate_linkedin_url(cls, v: HttpUrl):
-        v_str = str(v)
-        if not re.match(r"^https://(www\.)?linkedin\.com/in/[\w-]+/?$", v_str):
-            raise ValueError("LinkedIn profile URL must match https://linkedin.com/in/username")
+    @validator('bio')
+    def clean_bio(cls, v):
+        if v and "<" in v:
+            raise ValueError("Bio cannot contain HTML tags or scripts.")
         return v
 
 class UserUpdate(UserBase):

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -1,5 +1,5 @@
 from builtins import ValueError, any, bool, str
-from pydantic import BaseModel, EmailStr, Field, validator, root_validator
+from pydantic import BaseModel, EmailStr, Field, validator, root_validator, HttpUrl
 from typing import Optional, List
 from datetime import datetime
 from enum import Enum
@@ -24,7 +24,7 @@ class UserBase(BaseModel):
     last_name: Optional[str] = Field(None, example="Doe")
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
-    linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
+    linkedin_profile_url: Optional[str] = Field(None, example="https://linkedin.com/in/johndoe")
     github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
     role: UserRole
 
@@ -36,6 +36,14 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
     password: str = Field(..., min_length=8, example="Secure*1234")
+    nickname: str
+    first_name: Optional[str]
+    last_name: Optional[str]
+    bio: Optional[str]
+    profile_picture_url: Optional[HttpUrl]
+    linkedin_profile_url: Optional[HttpUrl]
+    github_profile_url: Optional[HttpUrl]
+    role: Optional[str]
 
     @validator('password')
     def password_must_not_be_blank(cls, value):
@@ -44,6 +52,20 @@ class UserCreate(UserBase):
         if len(value) < 8:
             raise ValueError("Password must be at least 8 characters long.")
         return value
+    
+    @validator("github_profile_url")
+    def validate_github_url(cls, v: HttpUrl):
+        v_str = str(v)
+        if not v_str.startswith("https://github.com/"):
+            raise ValueError("GitHub profile URL must start with https://github.com/")
+        return v
+
+    @validator("linkedin_profile_url")
+    def validate_linkedin_url(cls, v: HttpUrl):
+        v_str = str(v)
+        if not re.match(r"^https://(www\.)?linkedin\.com/in/[\w-]+/?$", v_str):
+            raise ValueError("LinkedIn profile URL must match https://linkedin.com/in/username")
+        return v
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -35,7 +35,15 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
-    password: str = Field(..., example="Secure*1234")
+    password: str = Field(..., min_length=8, example="Secure*1234")
+
+    @validator('password')
+    def password_must_not_be_blank(cls, value):
+        if not value or not value.strip():
+            raise ValueError("Password must not be empty or blank.")
+        if len(value) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        return value
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -71,10 +71,13 @@ class UserService:
 
             else:
                 new_user.verification_token = generate_verification_token()
-                await email_service.send_verification_email(new_user)
 
             session.add(new_user)
             await session.commit()
+            await session.refresh(new_user)
+            if new_user.role != UserRole.ADMIN:
+                await email_service.send_verification_email(new_user)
+
             return new_user
         except ValidationError as e:
             logger.error(f"Validation error during user creation: {e}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
     networks:
       - app-network
 
+    ports:
+      - "8000:8000"
+
   nginx:
     image: nginx:latest
     ports:


### PR DESCRIPTION
### Summary

This pull request fixes a bug where user-provided `nickname` values were being overridden by system-generated nicknames during registration.

### What was happening

The current logic in `User.create()` assigns a new nickname using `generate_nickname()` regardless of whether the user supplied one or not.

As a result, even when a user provides a valid nickname in the registration payload, it gets replaced by a generated one (e.g., `clever_fox_375`), which is unexpected behavior.

### Fixes

- Updated the logic to:
  - Check if the user provided a nickname.
  - Validate uniqueness if provided.
  - Generate one only if not supplied.
- Logs an error and aborts if a duplicate nickname is found.

### Code changes

```python
# Old logic (replaced)
new_nickname = generate_nickname()
while await cls.get_by_nickname(session, new_nickname):
    new_nickname = generate_nickname()
new_user.nickname = new_nickname

# New logic
nickname = validated_data.get('nickname')
if not nickname:
    nickname = generate_nickname()
    while await cls.get_by_nickname(session, nickname):
        nickname = generate_nickname()
else:
    if await cls.get_by_nickname(session, nickname):
        logger.error("Nickname already exists.")
        return None

new_user.nickname = nickname
